### PR TITLE
Hide alpha elements based on alphaChannel

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@blackbaud/skyux": "2.38.0",
     "@blackbaud/skyux-builder": "1.30.0",
-    "@blackbaud/skyux-cli": "1.6.2",
+    "@blackbaud/skyux-cli": "^1.6.2",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/colorpicker",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "SKY UX Colorpicker",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -9,7 +9,7 @@
     "skyux": "skyux",
     "start": "skyux serve --hmr",
     "test": "skyux test --coverage library --logFormat none",
-    "watch": "skyux watch",
+    "watch": "skyux watch --coverage library",
     "test:visual": "skyux e2e --logFormat none"
   },
   "keywords": [],
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@blackbaud/skyux": "2.38.0",
     "@blackbaud/skyux-builder": "1.30.0",
-    "@blackbaud/skyux-cli": "^1.6.2",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/colorpicker",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "SKY UX Colorpicker",
   "main": "bundles/bundle.umd.js",
   "module": "index.ts",
@@ -9,6 +9,7 @@
     "skyux": "skyux",
     "start": "skyux serve --hmr",
     "test": "skyux test --coverage library --logFormat none",
+    "watch": "skyux watch",
     "test:visual": "skyux e2e --logFormat none"
   },
   "keywords": [],
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@blackbaud/skyux": "2.38.0",
     "@blackbaud/skyux-builder": "1.30.0",
+    "@blackbaud/skyux-cli": "1.6.2",
     "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.5"
   }
 }

--- a/src/app/public/modules/colorpicker/colorpicker-input.directive.ts
+++ b/src/app/public/modules/colorpicker/colorpicker-input.directive.ts
@@ -100,6 +100,9 @@ export class SkyColorpickerInputDirective
   @Input()
   public alphaChannel = 'hex6';
 
+  @Input()
+  public allowTransparency = true;
+
   private _initialColor: string;
   private modelValue: SkyColorpickerOutput;
 
@@ -181,7 +184,8 @@ export class SkyColorpickerInputDirective
       this.initialColor,
       this.outputFormat,
       this.presetColors,
-      this.alphaChannel
+      this.alphaChannel,
+      this.allowTransparency
     );
   }
 

--- a/src/app/public/modules/colorpicker/colorpicker.component.html
+++ b/src/app/public/modules/colorpicker/colorpicker.component.html
@@ -41,7 +41,7 @@
                 [xAxis]="1"
                 (newColorContrast)="hue=$event"
                 class="hue"
-                [ngClass]="{'upper-slider': this.alphaChannel==='hex8'}"
+                [ngClass]="{'upper-slider': this.allowTransparency}"
                 #hueSlider>
                 <div
                   [style.left.px]="slider.hue"
@@ -49,7 +49,7 @@
                 </div>
               </div>
               <div
-                *ngIf="this.alphaChannel==='hex8'"
+                *ngIf="this.allowTransparency"
                 [skyColorpickerSlider]
                 [style.background-color]="alphaSliderColor"
                 [xAxis]="1"
@@ -86,7 +86,7 @@
                 {{ 'skyux_colorpicker_blue' | skyLibResources }}
               </label>
               <label
-                *ngIf="this.alphaChannel==='hex8'"
+                *ngIf="this.allowTransparency"
                 [for]="skyColorpickerAlphaId"
                 [attr.aria-label]="'skyux_colorpicker_aria_alpha' | skyLibResources">
                 {{ 'skyux_colorpicker_alpha' | skyLibResources }}
@@ -130,7 +130,7 @@
                 (newColorContrast)="blue=$event"
                 [value]="rgbaText?.blue">
               <input
-                *ngIf="this.alphaChannel==='hex8'"
+                *ngIf="this.allowTransparency"
                 [id]="skyColorpickerAlphaId"
                 [skyColorpickerText]
                 type="number"

--- a/src/app/public/modules/colorpicker/colorpicker.component.html
+++ b/src/app/public/modules/colorpicker/colorpicker.component.html
@@ -41,6 +41,7 @@
                 [xAxis]="1"
                 (newColorContrast)="hue=$event"
                 class="hue"
+                [ngClass]="{'upper-slider': this.alphaChannel==='hex8'}"
                 #hueSlider>
                 <div
                   [style.left.px]="slider.hue"
@@ -48,6 +49,7 @@
                 </div>
               </div>
               <div
+                *ngIf="this.alphaChannel==='hex8'"
                 [skyColorpickerSlider]
                 [style.background-color]="alphaSliderColor"
                 [xAxis]="1"
@@ -84,6 +86,7 @@
                 {{ 'skyux_colorpicker_blue' | skyLibResources }}
               </label>
               <label
+                *ngIf="this.alphaChannel==='hex8'"
                 [for]="skyColorpickerAlphaId"
                 [attr.aria-label]="'skyux_colorpicker_aria_alpha' | skyLibResources">
                 {{ 'skyux_colorpicker_alpha' | skyLibResources }}
@@ -127,6 +130,7 @@
                 (newColorContrast)="blue=$event"
                 [value]="rgbaText?.blue">
               <input
+                *ngIf="this.alphaChannel==='hex8'"
                 [id]="skyColorpickerAlphaId"
                 [skyColorpickerText]
                 type="number"

--- a/src/app/public/modules/colorpicker/colorpicker.component.scss
+++ b/src/app/public/modules/colorpicker/colorpicker.component.scss
@@ -176,6 +176,9 @@
     .right {
       flex: 1 1 auto;
       padding: 12px 8px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
     }
   }
   .hue {
@@ -183,9 +186,11 @@
     width: 100%;
     height: 16px;
     border: none;
-    margin-bottom: 16px;
     background-size: 100% 100%;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAAAQCAYAAAD06IYnAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AIWDwkUFWbCCAAAAFxJREFUaN7t0kEKg0AQAME2x83/n2qu5qCgD1iDhCoYdpnbQC9bbY1qVO/jvc6k3ad91s7/7F1/csgPrujuQ17BDYSFsBAWwgJhISyEBcJCWAgLhIWwEBYIi2f7Ar/1TCgFH2X9AAAAAElFTkSuQmCC');
+  }  
+  .upper-slider {
+    margin-bottom: 16px;
   }
   .alpha {
     cursor: pointer;

--- a/src/app/public/modules/colorpicker/colorpicker.component.spec.ts
+++ b/src/app/public/modules/colorpicker/colorpicker.component.spec.ts
@@ -334,6 +334,7 @@ describe('Colorpicker Component', () => {
 
     it('should accept a new RGBA color.', fakeAsync(() => {
       component.selectedOutputFormat = 'hex';
+      component.selectedHexType = 'hex8';
       openColorpicker(nativeElement, fixture);
       setInputElementValue(nativeElement, 'red', '163');
       setInputElementValue(nativeElement, 'green', '19');
@@ -433,6 +434,7 @@ describe('Colorpicker Component', () => {
 
     it('should accept mouse down events on alpha bar.', fakeAsync(() => {
       component.selectedOutputFormat = 'rgba';
+      component.selectedHexType = 'hex8';
       openColorpicker(nativeElement, fixture);
 
       const alphaBar = fixture.debugElement.query(By.css('.alpha'));
@@ -549,6 +551,7 @@ describe('Colorpicker Component', () => {
 
     it('should accept transparency', fakeAsync(() => {
       component.selectedOutputFormat = 'hsla';
+      component.selectedHexType = 'hex8';
       openColorpicker(nativeElement, fixture);
       setInputElementValue(nativeElement, 'red', '0');
       setInputElementValue(nativeElement, 'green', '0');
@@ -692,6 +695,36 @@ describe('Colorpicker Component', () => {
       fixture.detectChanges();
       tick();
       expect(nativeElement.querySelectorAll('.sky-colorpicker-reset-button').length).toEqual(1);
+    }));
+
+    it('should display alpha related elements when specified', fakeAsync(() => {
+      component.selectedOutputFormat = 'rgba';
+      component.selectedHexType = 'hex8';
+      fixture.detectChanges();
+      tick();
+
+      openColorpicker(nativeElement, fixture);
+
+      const alphaBar = fixture.debugElement.query(By.css('.alpha'));
+      expect(alphaBar).toBeTruthy();
+      const alphaInput = fixture.debugElement.query(By.css(
+        `#${component.colorpickerComponent.skyColorpickerAlphaId}`
+      ));
+      expect(alphaInput).toBeTruthy();
+    }));
+
+    it('should not display alpha related elements for alphaChannel hex6', fakeAsync(() => {
+      component.selectedHexType = 'hex6';
+      fixture.detectChanges();
+
+      openColorpicker(nativeElement, fixture);
+
+      const alphaBar = fixture.debugElement.query(By.css('.alpha'));
+      expect(alphaBar).toBeFalsy();
+      const alphaInput = fixture.debugElement.query(By.css(
+        `#${component.colorpickerComponent.skyColorpickerAlphaId}`
+      ));
+      expect(alphaInput).toBeFalsy();
     }));
 
   });

--- a/src/app/public/modules/colorpicker/colorpicker.component.spec.ts
+++ b/src/app/public/modules/colorpicker/colorpicker.component.spec.ts
@@ -697,9 +697,7 @@ describe('Colorpicker Component', () => {
       expect(nativeElement.querySelectorAll('.sky-colorpicker-reset-button').length).toEqual(1);
     }));
 
-    it('should display alpha related elements when specified', fakeAsync(() => {
-      component.selectedOutputFormat = 'rgba';
-      component.selectedHexType = 'hex8';
+    it('should display alpha related elements by default', fakeAsync(() => {
       fixture.detectChanges();
       tick();
 
@@ -713,8 +711,8 @@ describe('Colorpicker Component', () => {
       expect(alphaInput).toBeTruthy();
     }));
 
-    it('should not display alpha related elements for alphaChannel hex6', fakeAsync(() => {
-      component.selectedHexType = 'hex6';
+    it('should not display alpha related elements when allowTransparency is specified', fakeAsync(() => {
+      component.selectedTransparency = false;
       fixture.detectChanges();
 
       openColorpicker(nativeElement, fixture);

--- a/src/app/public/modules/colorpicker/colorpicker.component.ts
+++ b/src/app/public/modules/colorpicker/colorpicker.component.ts
@@ -68,6 +68,7 @@ export class SkyColorpickerComponent implements OnInit, OnDestroy {
   public skyColorpickerBlueId: string;
   public skyColorpickerAlphaId: string;
   public alphaChannel: string;
+  public allowTransparency: boolean;
   public alphaSliderColor: string;
   public arrowTop: number;
   public format: number;
@@ -123,12 +124,14 @@ export class SkyColorpickerComponent implements OnInit, OnDestroy {
     color: any,
     outputFormat: string,
     presetColors: Array<string>,
-    alphaChannel: string
+    alphaChannel: string,
+    allowTransparency: boolean
   ) {
     this.initialColor = color;
     this.outputFormat = outputFormat;
     this.presetColors = presetColors;
     this.alphaChannel = alphaChannel;
+    this.allowTransparency = allowTransparency;
 
     if (this.outputFormat === 'rgba') {
       this.format = 1;

--- a/src/app/public/modules/colorpicker/fixtures/colorpicker-component.fixture.html
+++ b/src/app/public/modules/colorpicker/fixtures/colorpicker-component.fixture.html
@@ -7,6 +7,7 @@
       [presetColors]="presetColors"
       [initialColor]="selectedColor"
       [outputFormat]="selectedOutputFormat"
-      [alphaChannel]="selectedHexType">
+      [alphaChannel]="selectedHexType"
+      [allowTransparency]="selectedTransparency">
   </sky-colorpicker>
 </div>

--- a/src/app/public/modules/colorpicker/fixtures/colorpicker-component.fixture.ts
+++ b/src/app/public/modules/colorpicker/fixtures/colorpicker-component.fixture.ts
@@ -26,6 +26,7 @@ export class ColorpickerTestComponent {
     '#68AFEF'
   ];
   public inputType = 'text';
+  public selectedTransparency = true;
 
   @ViewChild(SkyColorpickerComponent)
   public colorpickerComponent: SkyColorpickerComponent;

--- a/src/app/visual/colorpicker/colorpicker-visual.component.html
+++ b/src/app/visual/colorpicker/colorpicker-visual.component.html
@@ -17,6 +17,7 @@
       [presetColors]="presetColors2"
       [initialColor]="selectedColor2"
       [outputFormat]="selectedOutputFormat2"
+      alphaChannel="hex8"
       [(ngModel)]="color2"
     >
   </sky-colorpicker>

--- a/src/app/visual/colorpicker/colorpicker-visual.component.html
+++ b/src/app/visual/colorpicker/colorpicker-visual.component.html
@@ -5,6 +5,7 @@
       [presetColors]="presetColors1"
       [initialColor]="selectedColor1"
       [outputFormat]="selectedOutputFormat1"
+      alphaChannel="hex8"
       [(ngModel)]="color1"
     >
   </sky-colorpicker>
@@ -17,7 +18,6 @@
       [presetColors]="presetColors2"
       [initialColor]="selectedColor2"
       [outputFormat]="selectedOutputFormat2"
-      alphaChannel="hex8"
       [(ngModel)]="color2"
     >
   </sky-colorpicker>

--- a/src/app/visual/colorpicker/colorpicker-visual.component.html
+++ b/src/app/visual/colorpicker/colorpicker-visual.component.html
@@ -5,7 +5,6 @@
       [presetColors]="presetColors1"
       [initialColor]="selectedColor1"
       [outputFormat]="selectedOutputFormat1"
-      alphaChannel="hex8"
       [(ngModel)]="color1"
     >
   </sky-colorpicker>
@@ -18,6 +17,7 @@
       [presetColors]="presetColors2"
       [initialColor]="selectedColor2"
       [outputFormat]="selectedOutputFormat2"
+      [allowTransparency]="false"
       [(ngModel)]="color2"
     >
   </sky-colorpicker>


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux-colorpicker/issues/18.

Right now this is driven off of the specified alpha channel being set to hex8 in order to show the alpha elements:
- Slider
- 'A:' label
- Input for alpha value

This is a change to the default behavior of the colorpicker, what's the right way to communicate that? Or is there a better way to expose this change through a dedicated input value rather than implying it through `alphaChannel`?

I'm expecting the screenshot tests to fail, I'll fix them if y'all decide you want to use the PR.

![image](https://user-images.githubusercontent.com/4132425/60981258-00323d80-a304-11e9-8475-f7b1dec33f10.png)
