### PR TITLE
Release 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.3 (2021-03-18)
+
+- Replaced theme conditionals in templates with the new `skyIfTheme` directive. [#82](https://github.com/blackbaud/skyux-colorpicker/pull/82)
+
 # 4.2.2 (2020-12-07)
 
 - Added the missing `public_api.ts` file to expose the testing module's exports API. [#81](https://github.com/blackbaud/skyux-colorpicker/pull/81)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/colorpicker",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1188,9 +1188,9 @@
       }
     },
     "@blackbaud/auth-client": {
-      "version": "2.43.0",
-      "resolved": "https://registry.npmjs.org/@blackbaud/auth-client/-/auth-client-2.43.0.tgz",
-      "integrity": "sha512-KHG35LMPuaD/4ae4HR6Rq9AAxf7pgAiQSLZFvP2ZXjl7YGjr1WrhjERXNK86YHXrT2/Lxnj/SUpQNSMn/XovsQ==",
+      "version": "2.43.1",
+      "resolved": "https://registry.npmjs.org/@blackbaud/auth-client/-/auth-client-2.43.1.tgz",
+      "integrity": "sha512-RaZ0SKSB852dWKgst1PWsw4Sz0BLIpyFscwll3y8/a6E8DiWO9iT9seZSP2D6VfZUWLcKR+W0/fxMPJhkRXGaA==",
       "dev": true,
       "requires": {
         "@types/jwt-decode": "2.2.1",
@@ -1664,9 +1664,9 @@
       "dev": true
     },
     "@skyux/indicators": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@skyux/indicators/-/indicators-4.7.1.tgz",
-      "integrity": "sha512-Q7hqrfie7sjb0/LPAXady/wV9eIT1qegZUp2mP1qEBrTFoSred0VBKz0qgTqrNGBP3GL6uvhov0zUdEW3bZOaw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@skyux/indicators/-/indicators-4.8.0.tgz",
+      "integrity": "sha512-8AUzagn49i5w1CAL94Y9pahw9eLe7TY7ghzBixH6WS1qDqKlWv0cleqxiaujuI8ZEwWepIFXWuu7s3+bZZYzjA==",
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/colorpicker",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "SKY UX Colorpicker",
   "scripts": {
     "build": "skyux build-public-library --fullTemplateTypeChecking",
@@ -39,7 +39,7 @@
     "@angular/platform-browser": "9.1.13",
     "@angular/platform-browser-dynamic": "9.1.13",
     "@angular/router": "9.1.13",
-    "@blackbaud/auth-client": "2.43.0",
+    "@blackbaud/auth-client": "2.43.1",
     "@blackbaud/skyux-lib-clipboard": "4.0.0",
     "@blackbaud/skyux-lib-code-block": "4.0.2",
     "@blackbaud/skyux-lib-media": "4.0.0",
@@ -58,7 +58,7 @@
     "@skyux/forms": "4.15.2",
     "@skyux/http": "4.1.0",
     "@skyux/i18n": "4.0.3",
-    "@skyux/indicators": "4.7.1",
+    "@skyux/indicators": "4.8.0",
     "@skyux/inline-form": "4.1.0",
     "@skyux/layout": "4.4.3",
     "@skyux/lists": "4.6.0",


### PR DESCRIPTION
- Replaced theme conditionals in templates with the new `skyIfTheme` directive. [#82](https://github.com/blackbaud/skyux-colorpicker/pull/82)
